### PR TITLE
Added data functions for score and team providers

### DIFF
--- a/src/scripts/dataAccess.js
+++ b/src/scripts/dataAccess.js
@@ -1,22 +1,25 @@
+/*
+    Responsibility: create objects related to state
+    - applicationState object
+    - API target
+*/
 
-//include rounds in application state
-
-//send data back to database
-
-/* // temporary copy of api
+/*
+    applicationState is temporary state object
+    will be populated with players, teams, and scores data from api
+    has a gameState property pre-set so that default .gameState is a blank object
+*/
 export const applicationState = {
     // players:
     // teams:
     // scores:
-    // gameState: {
+    gameState: {}
         // team1Id: score,
         // team2Id: score,
         // team3Id: score,
         // roundNumber: integer
-    }
 }
-*/
 
 // define API
-
+export const API = "http://localhost:8088"
 

--- a/src/scripts/main.js
+++ b/src/scripts/main.js
@@ -1,3 +1,25 @@
-//import fetches, Truncheons function
+// import fetches, Truncheons function
+// import { applicationState } from "./dataAccess.js";
+import { fetchScores } from "./score/ScoreProvider.js";
+import { fetchTeams } from "./team/TeamProvider.js";
+
+const mainContainer = document.querySelector("#container")
+
+const renderAll = () => {
 //invokes fetches
+    const fetchArray = [ fetchScores(), fetchTeams() ]
+    return Promise.all(fetchArray)
+            .then(() => {
+                // renders html
+                // test with just raw applicationState
+                // mainContainer.innerHTML = JSON.stringify(applicationState)
+            })
+}
+
 //render html
+renderAll()
+
+// eventListener to re-render html on state change
+document.addEventListener("stateChanged", event => {
+    renderAllHTML()
+})

--- a/src/scripts/score/ScoreProvider.js
+++ b/src/scripts/score/ScoreProvider.js
@@ -1,7 +1,43 @@
+import { API, applicationState } from "../dataAccess.js";
+
 // export fetchScores - gets score data from api
+// gets score list from api, saves it to the applicationState
+export const fetchScores = () => {
+    return fetch(`${API}/scores`)
+        .then(response => response.json())
+        .then(
+            (scores) => {
+                // Store the external state in application state
+                applicationState.scores = scores
+            }
+        )
+}
 
 // export sendScore - add score data to api
+// takes a score object and sends it to the api
+export const sendScore = (score) => {
+    const fetchOptions = {
+        method: "POST",
+        headers: {
+            "Content-Type": "application/json"
+        },
+        body: JSON.stringify(score)
+    }
+
+
+    return fetch(`${API}/scores`, fetchOptions)
+        .then(response => response.json())
+}
 
 // export getScores - gets team score data from applicationState
+// returns a copy of score list from applicationState
+export const getScores = () => {
+    return applicationState.scores.map(score => ({...score}))
+}
 
 // export setScore(teamId, score) - add input to that teams respective value in gameState
+
+export const setScore = (teamId, score) => {
+    applicationState.gameState[teamId] += score
+    return ""
+}

--- a/src/scripts/team/TeamProvider.js
+++ b/src/scripts/team/TeamProvider.js
@@ -1,5 +1,36 @@
+import { API, applicationState } from "../dataAccess.js";
+
 //export fetchTeams
+// gets team list from api, saves it to the applicationState
+export const fetchTeams = () => {
+    return fetch(`${API}/teams`)
+        .then(response => response.json())
+        .then(
+            (teams) => {
+                // Store the external state in application state
+                applicationState.teams = teams
+            }
+        )
+}
 
 //export sendTeams
+// takes a team object and sends it to the api
+export const sendTeam = (team) => {
+    const fetchOptions = {
+        method: "POST",
+        headers: {
+            "Content-Type": "application/json"
+        },
+        body: JSON.stringify(team)
+    }
+
+
+    return fetch(`${API}/teams`, fetchOptions)
+        .then(response => response.json())
+}
 
 //export getTeams
+// returns a copy of team list from applicationState
+export const getTeams = () => {
+    return applicationState.teams.map(team => ({...team}))
+}


### PR DESCRIPTION
# Description

Added functions to ScoreProvider.js
- fetchScores() - gets score data from api
- sendScore() - sends a score object to api
- getScores() - gets scores from applicationState
- setScore() - adds team score to gameState score for the current game


Added functions to TeamProvider.js
- fetchTeams() - gets team list from api
- sendTeam() - adds team object to api
- getTeams() - gets list of teams from applicationState

Added applicationState object and API string to dataAccess.js

Added functions to main.js for testing purposes.

Fixes #15 
Fixes #16  (issues)

## Type of change

- New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- [x] Serve API
- [x] Serve web page
- [x] Page should make two fetch calls to API for scores and teams
- [x] score and team data should be added to applicationState after fetching
