### PR TITLE
Display Leaderboard

### DIFF
--- a/api/database.json
+++ b/api/database.json
@@ -4,11 +4,22 @@
       "id": 1,
       "fullname": "Joe Bob",
       "teamId": 1
-    },{
-        "id": 2,
-        "fullname": "Joe Bob",
-        "teamId": 2
-      }
+    },
+    {
+      "id": 2,
+      "fullname": "Joe Bob",
+      "teamId": 2
+    },
+    {
+      "fullName": "Billy Joel",
+      "teamId": 1,
+      "id": 3
+    },
+    {
+        "fullName": "Hank Hill",
+        "teamId": 3,
+        "id": 4
+    }  
   ],
   "teams": [
     {
@@ -18,6 +29,10 @@
     {
       "teamName": "Shepard",
       "id": 2
+    },
+    {
+      "teamName": "Cobras",
+      "id": 3
     }
   ],
   "scores": [
@@ -28,9 +43,15 @@
       "timeStamp": 1644376786060
     },
     {
-        "id": 2,
-        "gameScore": 6,
-        "teamId": 2,
+      "id": 2,
+      "gameScore": 6,
+      "teamId": 2,
+      "timeStamp": 1644376786060
+    },
+    {
+        "id": 3,
+        "gameScore": 5,
+        "teamId": 3,
         "timeStamp": 1644376786060
       }
   ]

--- a/api/database.json
+++ b/api/database.json
@@ -4,13 +4,21 @@
       "id": 1,
       "fullname": "Joe Bob",
       "teamId": 1
-    }
+    },{
+        "id": 2,
+        "fullname": "Joe Bob",
+        "teamId": 2
+      }
   ],
   "teams": [
     {
       "id": 1,
       "teamName": "Mongooses"
-    }
+    },
+    {
+        "id": 2,
+        "teamName": "Cobras"
+      }
   ],
   "scores": [
     {
@@ -18,6 +26,12 @@
       "gameScore": 4,
       "teamId": 1,
       "timeStamp": 1644376786060
-    }
+    },
+    {
+        "id": 2,
+        "gameScore": 6,
+        "teamId": 2,
+        "timeStamp": 1644376786060
+      }
   ]
 }

--- a/api/database.json
+++ b/api/database.json
@@ -1,27 +1,3 @@
-<<<<<<< HEAD
-{
-    "players": [
-        {
-            "id":1, "fullname":"Joe Bob", "teamId":1 
-        },
-        {
-            "id":2, "fullname":"Joe Bob", "teamId":1 
-        },
-        {
-            "id":3, "fullname":"Joe Bob", "teamId":1 
-        }
-    ],
-    "teams": [
-        {
-            "id":1, "teamName":"Mongooses"
-        }
-    ],
-    "scores": [
-        {
-            "id":1, "gameScore":4, "teamId":1, "timeStamp": 1644376786060
-        }
-    ]
-=======
 {
   "players": [
     {
@@ -44,5 +20,4 @@
       "timeStamp": 1644376786060
     }
   ]
->>>>>>> main
 }

--- a/src/scripts/Leaderboard.js
+++ b/src/scripts/Leaderboard.js
@@ -1,7 +1,19 @@
 //import function from scoreList
+import { TeamRows } from "./score/ScoreList.js";
 
 // function for leaderboard
-    //contains default html for headers
+export const Leaderboard = () => {
+
     //interpolate html by invoking scoreList function
     //return html
-    
+
+    return `<table>
+                    <tr>
+                        <th>Name</th>
+                        <th>Players</th>
+                        <th>Score</th>
+                    </tr>
+                    ${TeamRows()}
+                   </table>`
+
+}

--- a/src/scripts/Truncheons.js
+++ b/src/scripts/Truncheons.js
@@ -3,6 +3,7 @@
 //import { TeamForm } from "./team/TeamForm.js";
 //import { Leaderboard } from "./Leaderboard.js";
 import { PlayerForm } from "./player/PlayerForm.js";
+import { Leaderboard } from "./Leaderboard.js";
 
 
 //export function that interpolates entire html string
@@ -35,12 +36,12 @@ ${PlayerForm()}
     */
 
     // add leaderboard component
-    /* uncomment when Leaderboard ready
+    // uncomment when Leaderboard ready
     htmlString += `<article class="leaderboard">
                         ${Leaderboard()}
                     </article>
     `
-    */
+    
 
     //return html string
     return htmlString

--- a/src/scripts/main.js
+++ b/src/scripts/main.js
@@ -2,8 +2,6 @@
 // import { applicationState } from "./dataAccess.js";
 import { fetchPlayers } from "./player/PlayerProvider.js";
 import { fetchScores } from "./score/ScoreProvider.js";
-// import { totalScoreTest } from "./score/totalScore.js";
-import { gameTeamOptions } from "./team/TeamDropdown.js";
 import { fetchTeams } from "./team/TeamProvider.js";
 import { TruncheonsFlagons } from "./Truncheons.js";
 
@@ -18,8 +16,6 @@ const renderAll = () => {
                 mainContainer.innerHTML = `${TruncheonsFlagons()}`
                 // test with just raw applicationState
                 // mainContainer.innerHTML = JSON.stringify(applicationState)
-                //mainContainer.innerHTML = gameTeamOptions()
-                // const shouldBeTrue = totalScoreTest()
             })
 }
 

--- a/src/scripts/player/PlayerForm.js
+++ b/src/scripts/player/PlayerForm.js
@@ -1,9 +1,9 @@
 // import teamDropdown
 //import { allTeams } from "../TeamDropDown.js"
 // import PlayerCount
-import { resetPlayerTeam, sendPlayers } from "./PlayerProvider.js"
+import { sendPlayers } from "./PlayerProvider.js"
 import { PlayerCount } from "./PlayerCount.js"
-import { setPlayerTeam } from "./PlayerSelectedTeam.js"
+
 
 
 // function that generates html for the player form

--- a/src/scripts/player/PlayerProvider.js
+++ b/src/scripts/player/PlayerProvider.js
@@ -37,18 +37,4 @@ export const resetPlayerTeam = () => {
     return applicationState.playerTeam = null
 }
 
-/*xport const fetchPlayers = () => {
-    return fetch(`${API}/players`)
-        .then(response => response.json())
-        .then(
-            (players) => {
-                // Store the external state in application state
-                applicationState.players = players
-            }
-        )
-}
 
-export const getPlayers = () => {
-    return applicationState.players.map(player => ({...player}))
-}
-*/

--- a/src/scripts/score/ScoreList.js
+++ b/src/scripts/score/ScoreList.js
@@ -3,18 +3,33 @@ import { getTeams } from "../team/TeamProvider.js";
 import { totalScore } from "./totalScore.js";
 import { PlayerCount } from "../player/PlayerCount.js";
 
-//define function that iterates over teams
-export const LeaderBoard = () => {
+//sort all totalScores so the leaderboard is displayed in the right order
+const sortTotalScores = () => {
     const teams = getTeams()
-    let html = `<tr>`
+    //define an empty array
+    const scoreArr = []
 
-    //interpolate string for each team that displays team name, totalScore, and playerCount
     for (const team of teams) {
-        html += `<td>${team.teamName}</td>
-                 <td>${PlayerCount(team.id)}</td>
-                 <td>${totalScore(team.id)}</td>`
+        //for each team add their totalScore to that array
+        scoreArr.push(totalScore(team.id))
     }
-    html += `</tr>`
+
+    const sortedScores = scoreArr.sort(( score1, score2) => score2 - score1)
+    return sortedScores
+}
+
+
+//define function that iterates over teams
+export const TeamRows = () => {
+    const teams = getTeams()
+    let html = ""
+        
+        //interpolate string for each team that displays team name, totalScore, and playerCount
+        html += `<tr>
+                    <td>${team.teamName}</td>
+                    <td>${PlayerCount(team.id)}</td>
+                    <td>${totalScore(team.id)}</td>
+                </tr>`
     //return html
     
     return html

--- a/src/scripts/score/ScoreList.js
+++ b/src/scripts/score/ScoreList.js
@@ -1,16 +1,22 @@
 //import getTeams, totalScore, import playerCount
-import { getTeams } from "../team/TeamProvider";
-import { totalScore} from "./totalScore.js";
+import { getTeams } from "../team/TeamProvider.js";
+import { totalScore } from "./totalScore.js";
+import { PlayerCount } from "../player/PlayerCount.js";
 
 //define function that iterates over teams
 export const LeaderBoard = () => {
     const teams = getTeams()
-    let html = ``
+    let html = `<tr>`
 
-    for (const team of teams) {
-
-    }
-}
     //interpolate string for each team that displays team name, totalScore, and playerCount
+    for (const team of teams) {
+        html += `<td>${team.teamName}</td>
+                 <td>${PlayerCount(team.id)}</td>
+                 <td>${totalScore(team.id)}</td>`
+    }
+    html += `</tr>`
     //return html
+    
+    return html
+}
 

--- a/src/scripts/score/ScoreList.js
+++ b/src/scripts/score/ScoreList.js
@@ -1,6 +1,16 @@
 //import getTeams, totalScore, import playerCount
+import { getTeams } from "../team/TeamProvider";
+import { totalScore} from "./totalScore.js";
 
 //define function that iterates over teams
+export const LeaderBoard = () => {
+    const teams = getTeams()
+    let html = ``
+
+    for (const team of teams) {
+
+    }
+}
     //interpolate string for each team that displays team name, totalScore, and playerCount
     //return html
 

--- a/src/scripts/score/ScoreList.js
+++ b/src/scripts/score/ScoreList.js
@@ -3,27 +3,21 @@ import { getTeams } from "../team/TeamProvider.js";
 import { totalScore } from "./totalScore.js";
 import { PlayerCount } from "../player/PlayerCount.js";
 
-//sort all totalScores so the leaderboard is displayed in the right order
-const sortTotalScores = () => {
-    const teams = getTeams()
-    //define an empty array
-    const scoreArr = []
-
-    for (const team of teams) {
-        //for each team add their totalScore to that array
-        scoreArr.push(totalScore(team.id))
-    }
-
-    const sortedScores = scoreArr.sort(( score1, score2) => score2 - score1)
-    return sortedScores
-}
 
 
 //define function that iterates over teams
 export const TeamRows = () => {
     const teams = getTeams()
+    //make a copy of teams array and save their totalScore as a property
+    const totalTeamScores = teams.map((team) => ({
+        ...team,
+        totalScore: totalScore(team.id)
+    }))
+    
+    //sort all teams by their totalScore property so the leaderboard is displayed in the right order
+    const sortedTeams = totalTeamScores.sort(( team1, team2) => team2.totalScore - team1.totalScore)
     let html = ""
-        
+        for (const team of sortedTeams)
         //interpolate string for each team that displays team name, totalScore, and playerCount
         html += `<tr>
                     <td>${team.teamName}</td>


### PR DESCRIPTION
Added functions that sort all teams by their totalScores and then displays leaderboard containing team names, player count, and their respective score.

Fixes # (3, 19)

## Type of change

- New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- [ ] Serve API
- [ ] Serve branch
- [ ] When page loads you should see a table of teams sorted by descending score totals
